### PR TITLE
docs: Add the ec2:DescribeImages action to controller IAM role

### DIFF
--- a/website/content/en/v0.16.1/getting-started/migrating-from-cas/scripts/step05-controller-iam.sh
+++ b/website/content/en/v0.16.1/getting-started/migrating-from-cas/scripts/step05-controller-iam.sh
@@ -39,6 +39,7 @@ echo '{
                 "ec2:CreateLaunchTemplate",
                 "ec2:CreateFleet",
                 "ec2:DescribeSpotPriceHistory",
+                "ec2:DescribeImages",
                 "pricing:GetProducts"
             ],
             "Effect": "Allow",


### PR DESCRIPTION
**Description**
Adding the missing `ec2:DescribeImages` action to the controller IAM role

**Does this change impact docs?**
- [x] Yes, PR includes docs updates


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
